### PR TITLE
Add NatGatewayId to AWS::EC2::Route

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -250,6 +250,7 @@ class Route(AWSObject):
         'DestinationCidrBlock': (basestring, True),
         'GatewayId': (basestring, False),
         'InstanceId': (basestring, False),
+        'NatGatewayId': (basestring, False),
         'NetworkInterfaceId': (basestring, False),
         'RouteTableId': (basestring, True),
         'VpcPeeringConnectionId': (basestring, False),


### PR DESCRIPTION
Per [AWS::EC2::Route](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-route.html) documentation, there's a new NatGatewayId field.

See also: https://github.com/cloudtools/troposphere/pull/394